### PR TITLE
Fix URL for self-managed SA PAT create

### DIFF
--- a/create-serviceaccount-self-managed.sh
+++ b/create-serviceaccount-self-managed.sh
@@ -32,7 +32,7 @@ SA_NAME=`echo "$SA_RESP" | jq -r '.name'`
 echo "Successfully created service account $SA_NAME with ID $SA_ID."
 
 # Generate an access token for the service account. This access token will be sent to Datadog in the next step.
-if ! TOKEN_RESP=`curl -sS --fail-with-body -X POST "https://$GITLAB_HOSTNAME/api/v4/service_accounts/$SA_ID/personal_access_tokens" \
+if ! TOKEN_RESP=`curl -sS --fail-with-body -X POST "https://$GITLAB_HOSTNAME/api/v4/users/$SA_ID/personal_access_tokens" \
     -H "Content-Type: application/json" \
     -H "PRIVATE-TOKEN: $GITLAB_ADMIN_TOKEN" \
     -d "{


### PR DESCRIPTION
This PR updates the path used to create a Service Account's personal access token in the self-managed flavor of the installation.

The [docs for service account setup](https://docs.gitlab.com/ee/user/profile/service_accounts.html#administrators-in-gitlab-self-managed) redirect to [this "users" REST API](https://docs.gitlab.com/ee/api/user_tokens.html#create-a-personal-access-token) in the self-managed setup.