### PR TITLE
Remove uuidgen depency and document the others

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ Installing the integration will require some calls to Datadog’s API, for which
 
 **Please generate an [API key](https://docs.datadoghq.com/account_management/api-app-keys/) *dedicated to the GitLab integration*; it will be used by your GitLab instance to authenticate webhooks sent to Datadog, and revoking it will break the integration.**
 
+### Script dependencies
+
+The execution of the scripts in this repository requires the installation of the following packages:
+* `coreutils`
+* `jq`
+* `curl`
+
+Example installation oneliners:
+* `brew install coreutils jq curl` (macOS)
+* `apt-get install coreutils jq curl` (Ubuntu)
+
 ## Installation
 
 For the shell snippets & scripts below, please configure the following environment variables:

--- a/create-oauth-app.sh
+++ b/create-oauth-app.sh
@@ -44,7 +44,7 @@ if ! DD_RESP=`curl -sS --fail-with-body -X POST https://api.$DD_SITE/api/v2/sour
   -H "DD-APPLICATION-KEY: $DD_APPLICATION_KEY" \
   -d "{
 	\"data\": {
-		\"id\": \"$(uuidgen)\",
+		\"id\": \"3e302f18-b6d4-11ef-a139-e7811914ad2b\",
 		\"type\": \"source_code_gitlab_private_oauth_app_creation\",
 		\"attributes\": {
 			\"name\": \"$APP_NAME\",

--- a/create-serviceaccount-gitlab-com.sh
+++ b/create-serviceaccount-gitlab-com.sh
@@ -65,7 +65,7 @@ if ! DD_RESP=`curl -sS --fail-with-body -X POST https://api.$DD_SITE/api/v2/sour
     -H "DD-APPLICATION-KEY: $DD_APPLICATION_KEY" \
     -d "{
         \"data\": {
-            \"id\": \"$(uuidgen)\",
+            \"id\": \"3e302f18-b6d4-11ef-a139-e7811914ad2b\",
             \"type\": \"source_code_gitlab_token_creation\",
             \"attributes\": {
                 \"secret_token\": \"$(echo "$TOKEN_RESP" | jq -r '.token')\",

--- a/create-serviceaccount-self-managed.sh
+++ b/create-serviceaccount-self-managed.sh
@@ -52,7 +52,7 @@ if ! DD_RESP=`curl -sS --fail-with-body -X POST https://api.$DD_SITE/api/v2/sour
     -H "DD-APPLICATION-KEY: $DD_APPLICATION_KEY" \
     -d "{
         \"data\": {
-            \"id\": \"$(uuidgen)\",
+            \"id\": \"3e302f18-b6d4-11ef-a139-e7811914ad2b\",
             \"type\": \"source_code_gitlab_token_creation\",
             \"attributes\": {
                 \"secret_token\": \"$(echo "$TOKEN_RESP" | jq -r '.token')\",


### PR DESCRIPTION
This PR removes the `uuidgen` dependency in the scripts and adds oneliners in the README for the installation of the packages needed.